### PR TITLE
Add print functionality for todos with print button and styles

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -17,6 +17,7 @@
                     🔔 <span id="notificationCount" class="badge">0</span>
                 </button>
                 <button id="settingsBtn" class="btn-icon" title="Settings">⚙️</button>
+                <button id="printBtn" class="btn-icon" title="Print">🖨️</button>
             </div>
         </header>
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -398,6 +398,71 @@ body {
     color: var(--text-secondary);
 }
 
+@media print {
+    .header-actions,
+    .filter-buttons,
+    .search-box,
+    .priority-filter,
+    .add-todo-section,
+    .todo-actions,
+    .modal,
+    .toast-container,
+    .btn-icon,
+    .btn-primary,
+    .btn-secondary,
+    .filter-btn,
+    .loading,
+    #notificationCount {
+        display: none !important;
+    }
+
+    .header {
+        border: none;
+        margin-bottom: 10px;
+    }
+
+    body, .container {
+        background: #fff !important;
+        color: #111 !important;
+    }
+
+    .todo-card {
+        box-shadow: none !important;
+        border-left-width: 6px !important;
+        background: transparent !important;
+        padding: 12px !important;
+        page-break-inside: avoid !important;
+        break-inside: avoid !important;
+        -webkit-print-color-adjust: exact !important;
+    }
+
+    .todo-title {
+        color: #111 !important;
+        font-size: 1.05rem !important;
+    }
+
+    .todo-description,
+    .todo-meta,
+    .todo-tags {
+        color: #222 !important;
+    }
+
+    .page-break {
+        display: block;
+        page-break-after: always !important;
+    }
+
+    .hidden { display: none !important; }
+}
+
+.print-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+.print-filters { color: #444; font-size: 0.9rem; }
+
 .empty-state h3 {
     font-size: 1.5rem;
     margin-bottom: 10px;


### PR DESCRIPTION
### **📌 Overview**

This PR introduces a print feature for the Todos list, allowing users to easily print their tasks in a clean and formatted layout. A dedicated **Print** button has been added to the UI, which triggers the browser’s print dialog and uses custom print styles for a clean output.

 fixes #20
---

### **🔧 What’s Added / Changed**

#### **1. Print Button Added**

* A new **Print** button is placed on the Todos page.
* Clicking the button calls `window.print()` to open the print dialog.

#### **2. Print-Friendly Styles**

* Added a print-specific CSS section using `@media print`.
* Hidden non-essential UI elements during printing (buttons, headers, side panels, etc.).
* Improved the layout for printed pages:

  * Clean font styling
  * Proper spacing between todo items
  * Removed background colors
  * Ensured contrast for better readability





### **📁 Files Modified**
static/styles.css
static/app.js
static/index.html
***Screnshots ***
 
<img width="1898" height="287" alt="image" src="https://github.com/user-attachments/assets/bc54bfa8-9f16-47a0-a1ce-34950f7f9414" />
<img width="1919" height="522" alt="image" src="https://github.com/user-attachments/assets/2828801a-c6ee-490b-a9e4-1f75f5128617" />


